### PR TITLE
Make console reporter return a unique_ptr

### DIFF
--- a/example/example.cc
+++ b/example/example.cc
@@ -68,8 +68,7 @@ int main(int argc, char **argv) {
     bar(iters);
     slow(iters);
 
-    ccmetrics::PeriodicReporter *reporter =
-        ccmetrics::mkConsoleReporter(&registry());
+    auto reporter = ccmetrics::mkConsoleReporter(&registry());
     reporter->report();
     return 0;
 }

--- a/src/ccmetrics/reporting/periodic_reporter.h
+++ b/src/ccmetrics/reporting/periodic_reporter.h
@@ -22,6 +22,7 @@
 #define SRC_CCMETRICS_REPORTING_PERIODIC_REPORTER_H_
 
 #include <chrono>
+#include <memory>
 
 #include "ccmetrics/metric_registry.h"
 #include "ccmetrics/porting.h"
@@ -46,6 +47,12 @@ public:
 
     /** Implementation-specific report method. */
     virtual void report() NOEXCEPT = 0;
+
+    // Ensures safe deletion of objects produced in a dll on Windows
+    class CCMETRICS_SYM Deleter {
+    public:
+        void operator()(PeriodicReporter *pr);
+    };
 private:
     void doStart(std::chrono::milliseconds const& period);
 
@@ -53,7 +60,8 @@ private:
 };
 
 /** @return a new periodic reporter that sends reports to stdout. */
-CCMETRICS_SYM PeriodicReporter* mkConsoleReporter(MetricRegistry *registry);
+CCMETRICS_SYM std::unique_ptr<PeriodicReporter, PeriodicReporter::Deleter>
+mkConsoleReporter(MetricRegistry *registry);
 
 } // ccmetrics namespace
 

--- a/src/reporting/console_reporter.cc
+++ b/src/reporting/console_reporter.cc
@@ -135,8 +135,10 @@ void ConsoleReporter::printWithBanner(std::string const& str, char sym) {
         std::string(kConsoleWidth - str.size(), sym).c_str());
 }
 
-PeriodicReporter* mkConsoleReporter(MetricRegistry *registry) {
-    return new ConsoleReporter(registry);
+std::unique_ptr<PeriodicReporter, PeriodicReporter::Deleter>
+mkConsoleReporter(MetricRegistry *registry) {
+    return std::unique_ptr<PeriodicReporter, PeriodicReporter::Deleter>(
+        new ConsoleReporter(registry), PeriodicReporter::Deleter());
 }
 
 } // ccmetrics namespace

--- a/src/reporting/periodic_reporter.cc
+++ b/src/reporting/periodic_reporter.cc
@@ -87,4 +87,8 @@ void PeriodicReporter::stop() {
     impl_->stop();
 }
 
+void PeriodicReporter::Deleter::operator()(PeriodicReporter *reporter) {
+    delete reporter;
+}
+
 } // ccmetrics namespace

--- a/test/reporting_test.cc
+++ b/test/reporting_test.cc
@@ -53,7 +53,7 @@ TEST(ReportingTest, BasicFunctionality) {
 
 TEST(ReportingTest, ConsoleReporterSmokeTest) {
     MetricRegistry registry;
-    std::unique_ptr<PeriodicReporter> reporter(mkConsoleReporter(&registry));
+    auto reporter = mkConsoleReporter(&registry);
     reporter->report();
 
     auto counter = registry.counter("foo_counter");


### PR DESCRIPTION
 - helps library consumers avoid leaks
 - prevents multi-runtime errors on Windows